### PR TITLE
fix(api/user):apiname命名为相同长度中文时只显示一个

### DIFF
--- a/app/apidoc/api/user.js
+++ b/app/apidoc/api/user.js
@@ -27,7 +27,7 @@
 /**
  * @api {DELETE} /user/:_id delete a user
  * @apiDescription 用户删除的接口
- * @apiName 删除用户
+ * @apiName 删除某个用户
  * @apiGroup User
  * @apiParam {String} _id 用户的id
  * @apiSuccessExample Success-Response:


### PR DESCRIPTION
修复@apiname命名为相同长度中文时只显示一个
[apidoc生成接口文档，同一个apiGroup下无法生成多个接口](https://segmentfault.com/q/1010000016609861)
原因应该是中文乱码导致的
建议@apiname命名规范化